### PR TITLE
feat(plugin): send version in crawl call

### DIFF
--- a/frontend/src/AutocompleteWrapper.ts
+++ b/frontend/src/AutocompleteWrapper.ts
@@ -16,6 +16,7 @@ import type { Options } from './options';
 import { templates } from './templates';
 import { addCss } from './addCss';
 
+// @ts-ignore
 import { version } from '../package.json';
 
 export type SizeModifier = null | 'xs' | 'sm';

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["es2020", "DOM"],
-    "resolveJsonModule": true,
-    "rootDir": ".",
+    "rootDir": "src",
     /* Use a fake outDir */
     "outDir": "dist-webpack-never-used"
   },

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -1,5 +1,8 @@
 import fetch from 'node-fetch';
 
+// @ts-ignore
+import { version } from '../package.json';
+
 interface BuildParams {
   constants: {
     SITE_ID: string;
@@ -74,7 +77,7 @@ export async function onSuccess(params: BuildParams): Promise<void> {
         Authorization: `Basic ${Buffer.from(creds).toString('base64')}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ branch, siteName, deployPrimeUrl }),
+      body: JSON.stringify({ branch, siteName, deployPrimeUrl, version }),
     });
 
     if (!response.ok) {

--- a/plugin/tsconfig.json
+++ b/plugin/tsconfig.json
@@ -2,10 +2,7 @@
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "baseUrl": ".",
-    "outDir": "./dist",
+    "outDir": "./dist"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
Send version in crawl call.
Took the opportunity to replace `resolveJsonModule` with a simple ts-ignore in both plugin and frontend.