### PR TITLE
feat(frontend): handle content snippeting

### DIFF
--- a/frontend/src/data.ts
+++ b/frontend/src/data.ts
@@ -1,0 +1,8 @@
+export interface Data {
+  url: string;
+
+  title: string;
+  description: string;
+
+  content: string;
+}

--- a/frontend/src/templates.ts
+++ b/frontend/src/templates.ts
@@ -1,3 +1,7 @@
+import type { Hit } from '@algolia/client-search';
+
+import { SizeModifier } from './AutocompleteWrapper';
+import { Data } from './data';
 import { escapeHTML } from './escapeHTML';
 
 export interface Templates {
@@ -5,7 +9,9 @@ export interface Templates {
   autocomplete: {
     css: (color: string) => string;
     poweredBy: (algoliaLogoHtml: string) => string;
-    suggestion: (hit: any) => string;
+    suggestion: (
+      hit: Hit<Data> & { sizeModifier: SizeModifier; snippet: string }
+    ) => string;
   };
 }
 
@@ -37,8 +43,8 @@ export const templates: Templates = {
       </div>`,
     suggestion: (hit) => `
       <div class="aa-hit aa-hit__${hit.sizeModifier}">
-        <div class="aa-hit--title">${hit._highlightResult.title.value}</div>
-        <div class="aa-hit--description">${hit._snippetResult.description.value}</div>
+        <div class="aa-hit--title">${hit._highlightResult!.title.value}</div>
+        <div class="aa-hit--description">${hit.snippet}</div>
       </div>
     `,
   },


### PR DESCRIPTION
Display the description by default, but depending on the match level of content, display content snippet instead.
Managed to type the `Hit`s at the same time.

Showing description:
<img width="628" alt="image" src="https://user-images.githubusercontent.com/5095856/94590752-7c0d0280-0287-11eb-816e-e731c33b95a5.png">

Showing content:
<img width="638" alt="image" src="https://user-images.githubusercontent.com/5095856/94590775-86c79780-0287-11eb-9f18-7b735307527a.png">
