### PR TITLE
fix(dev): fix fork-ts-checker config options

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -28,11 +28,12 @@ function plugins({ production }) {
     additionalPlugins = [
       new HotModuleReplacementPlugin(),
       new ForkTsCheckerWebpackPlugin({
-        tsconfig: 'tsconfig.json',
-        compilerOptions: {
-          skipLibCheck: true,
+        typescript: {
+          configFile: 'tsconfig.json',
         },
-        eslint: true,
+        eslint: {
+          files: 'src/**/*.{js,ts}',
+        },
       }),
     ];
   }


### PR DESCRIPTION
I've just merged https://github.com/algolia/algoliasearch-netlify/pull/37 , which updated the major version of the tool.
I didn't realize the options had changed too.