### PR TITLE
feat(plugin): add "branches" input

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,5 @@ ALGOLIA_API_KEY=
 ALGOLIA_BASE_URL=https://crawler.algolia.com
 
 # Netlify spec
-BRANCH="master"
 SITE_NAME="algoliasearch-netlify"
 DEPLOY_PRIME_URL="https://master--algoliasearch-netlify.netlify.app"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ Once you've installed the plugin, your next Netlify deploy will trigger a crawl 
 
 When it receives a build hook, the Algolia Crawler processes your website asynchronously. This operation takes some time, resulting in a short delay between the first deploy and the associated crawl. Your site and your Algolia index will be out of sync during that delay.
 
-You can find information about your current crawler in the [Netlify deploy logs](https://docs.netlify.com/monitor-sites/logs/#deploy-log). We create one crawler (targeting one Algolia index) per Git branch, so that you can have, for example, a production index on `master` and development index on `develop`.
+You can find information about your current crawler in the [Netlify deploy logs](https://docs.netlify.com/monitor-sites/logs/#deploy-log).
+
+> Note: by default, we only build the main branch (`main` or `master`). We can however create one crawler (targeting one Algolia index) per Git branch, so that you can have, for example, a production index on `master` and development index on `develop`. You need to configure the [`branches` plugin input](./plugin#available-parameters) to enable this feature.
 
 <img src="/docs/screenshots/deploy-logs.png?raw=true" alt="Netlify deploy logs.">
 
@@ -127,6 +129,7 @@ ALGOLIA_DISABLED=true
 ```
 
 ### Uninstall
+
 To uninstall the plugin, go to your [Crawler Admin Console](https://crawler.algolia.com/admin/netlify) and click **Uninstall**. It automatically cleans up the environment variables and deletes associated data from Algolia.
 
 You can also go to your [Netlify plugins](https://app.netlify.com/plugins) and click **Options > Uninstall plugin**. Note that this won't clean your data on our end.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ When it receives a build hook, the Algolia Crawler processes your website asynch
 
 You can find information about your current crawler in the [Netlify deploy logs](https://docs.netlify.com/monitor-sites/logs/#deploy-log).
 
-> Note: by default, we only build the main branch (`main` or `master`). We can however create one crawler (targeting one Algolia index) per Git branch, so that you can have, for example, a production index on `master` and development index on `develop`. You need to configure the [`branches` plugin input](./plugin#available-parameters) to enable this feature.
+> Note: by default, we only build the `master` branch. We can however create one crawler (targeting one Algolia index) per Git branch, so that you can have, for example, a production index on `master` and development index on `develop`. You need to configure the [`branches` plugin input](./plugin#available-parameters) to enable this feature.
 
 <img src="/docs/screenshots/deploy-logs.png?raw=true" alt="Netlify deploy logs.">
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -17,11 +17,6 @@ It's designed to be compatible with the index structure extracted by the [plugin
 </script>
 ```
 
-## Scripts
-
-- `yarn dev`: run dev environment
-- `yarn release`: build & publish the library
-
 ## Available options
 
 Here's the full list of options with their default value.
@@ -45,10 +40,22 @@ algoliasearchNetlify({
 });
 ```
 
+## Scripts
+
+- `yarn dev`: run dev environment
+- `yarn release`: build & publish the library
+
+
 ## Development
 
+From this folder:
 ```sh
 yarn dev
+```
+
+Or from the root of the repository:
+```sh
+yarn dev:frontend
 ```
 
 This runs a `webpack-dev-server` on port 9100.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -10,8 +10,19 @@ It will trigger a crawl on each successful build.
 Plugin inputs can be set in `netlify.toml`. They're all optional.
 
 - `branches` - _Default: `['main', 'master']`_ - List of branches the crawler should build.  
-  Each of those will have a dedicated Algolia index.
+  By default, we only build your main branch, but this can be used to build multiple branches.
+  Each of those will have a dedicated Algolia index, named `netlify_<site-id>_<branch-name>_all`.
+  To target the right branch, you will need to inject the `HEAD` environment variable in your front-end code.
 - `disabled` - _Default: `false`_ - Use to disable the plugin without removing it.
+
+Example:
+
+```toml
+[[plugins]]
+package = "@algolia/netlify-plugin-crawler"
+  [plugins.inputs]
+  branches = ['master', 'develop', 'feat/add-algolia']
+```
 
 ### Environment variables
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -9,7 +9,7 @@ It will trigger a crawl on each successful build.
 
 Plugin inputs can be set in `netlify.toml`. They're all optional.
 
-- `branches` - _Default: ['main', 'master']_ - List of branches the crawler should build. Each of those will have a dedicated Algolia index.
+- `branches` - _Default: `['main', 'master']`_ - List of branches the crawler should build. Each of those will have a dedicated Algolia index.
 - `disabled` - _Default: `false`_ - Use to disable the plugin without removing it.
 
 ### Environment variables

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -3,10 +3,20 @@
 This plugin links your Netlify site with Algolia's Crawler.  
 It will trigger a crawl on each successful build.
 
-## Environment variables
+## Available parameters
 
-- `ALGOLIA_API_KEY` [Optional in dev] API Key to authenticate the call to the crawler.
-- `ALGOLIA_BASE_URL` [Optional] Defaults to `https://crawler.algolia.com/`.
+### Inputs
+
+Plugin inputs can be set in `netlify.toml`. They're all optional.
+
+- `branches` - _Default: ['main', 'master']_ - List of branches the crawler should build. Each of those will have a dedicated Algolia index.
+- `disabled` - _Default: `false`_ - Use to disable the plugin without removing it.
+
+### Environment variables
+
+- `ALGOLIA_BASE_URL`: URL to target, usually https://crawler.algolia.com/. Can be modified locally to target a local instance of the crawler (only for Algolia employees).
+- `ALGOLIA_API_KEY`: [Optional in dev] API Key to authenticate the call to the crawler.
+- `ALGOLIA_DISABLED`: [Optional] Set to `true` to disable the plugin without removing it.
 
 For a local run, those need to be set in `.env` using `cp .env.example .env` and modifying the values to fit your needs.
 
@@ -38,8 +48,16 @@ For a local run, those need to be set in `.env` using `cp .env.example .env` and
 
 ### Running the dev env
 
+From this folder:
+
 ```sh
 yarn dev
+```
+
+Or from the root of the repository:
+
+```sh
+yarn dev:plugin
 ```
 
 It builds the site locally, running the local version of the plugin.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -9,7 +9,7 @@ It will trigger a crawl on each successful build.
 
 Plugin inputs can be set in `netlify.toml`. They're all optional.
 
-- `branches` - _Default: `['main', 'master']`_ - List of branches the crawler should build.  
+- `branches` - _Default: `['master']`_ - List of branches the crawler should build.  
   By default, we only build your main branch, but this can be used to build multiple branches.
   Each of those will have a dedicated Algolia index, named `netlify_<site-id>_<branch-name>_all`.
   To target the right branch, you will need to inject the `HEAD` environment variable in your front-end code.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -9,12 +9,14 @@ It will trigger a crawl on each successful build.
 
 Plugin inputs can be set in `netlify.toml`. They're all optional.
 
-- `branches` - _Default: `['main', 'master']`_ - List of branches the crawler should build. Each of those will have a dedicated Algolia index.
+- `branches` - _Default: `['main', 'master']`_ - List of branches the crawler should build.  
+  Each of those will have a dedicated Algolia index.
 - `disabled` - _Default: `false`_ - Use to disable the plugin without removing it.
 
 ### Environment variables
 
-- `ALGOLIA_BASE_URL`: URL to target, usually https://crawler.algolia.com/. Can be modified locally to target a local instance of the crawler (only for Algolia employees).
+- `ALGOLIA_BASE_URL`: URL to target, usually https://crawler.algolia.com/.  
+  Can be modified locally to target a local instance of the crawler (only for Algolia employees).
 - `ALGOLIA_API_KEY`: [Optional in dev] API Key to authenticate the call to the crawler.
 - `ALGOLIA_DISABLED`: [Optional] Set to `true` to disable the plugin without removing it.
 

--- a/plugin/manifest.yml
+++ b/plugin/manifest.yml
@@ -2,3 +2,7 @@ name: '@algolia/netlify-plugin-crawler'
 inputs:
   - name: disabled
     description: Disable the plugin
+    default: false
+  - name: branches
+    description: Branches to index. Each branch in this array will have its content crawled in a dedicated index.
+    default: ['main', 'master']

--- a/plugin/manifest.yml
+++ b/plugin/manifest.yml
@@ -5,4 +5,4 @@ inputs:
     default: false
   - name: branches
     description: Branches to index. Each branch in this array will have its content crawled in a dedicated index.
-    default: ['main', 'master']
+    default: ['master']

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -36,8 +36,8 @@ export async function onSuccess(params: BuildParams): Promise<void> {
   console.log('Algolia Netlify plugin started');
 
   // Debug
-  console.log(JSON.stringify(params, null, 2));
-  console.log(JSON.stringify(process.env, null, 2));
+  // console.log(JSON.stringify(params, null, 2));
+  // console.log(JSON.stringify(process.env, null, 2));
 
   const { utils, inputs, constants } = params;
 

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -50,6 +50,8 @@ export async function onSuccess(params: BuildParams): Promise<void> {
   const siteId = constants.SITE_ID;
   const isLocal = constants.IS_LOCAL;
 
+  // HEAD is incorrect locally if you try to run `yarn netlify build`
+  // before having pushed your first commit on this branch, it says `master`
   const branch = process.env.HEAD!;
   const siteName = process.env.SITE_NAME;
   const deployPrimeUrl = process.env.DEPLOY_PRIME_URL;

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -36,8 +36,8 @@ export async function onSuccess(params: BuildParams): Promise<void> {
   console.log('Algolia Netlify plugin started');
 
   // Debug
-  // console.log(JSON.stringify(params, null, 2));
-  // console.log(JSON.stringify(process.env, null, 2));
+  console.log(JSON.stringify(params, null, 2));
+  console.log(JSON.stringify(process.env, null, 2));
 
   const { utils, inputs, constants } = params;
 


### PR DESCRIPTION
For now only target `master` by default.
When we'll find a way to use `site.build_settings.repo_branch` in the plugin, we'll be able to use that instead.

I haven't updated the frontend README, because it's going to change anyway with the introduction of `siteId` & `branch` params instead of `indexName`.