### PR TITLE
fix(webpack): fix dev server command

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "build": "npx webpack --mode production",
-    "dev": "PORT=9100 npx webpack-dev-server --mode development",
+    "dev": "PORT=9100 npx webpack serve --mode development",
     "postinstall": "[ -d dist/ ] || npm run build"
   },
   "devDependencies": {


### PR DESCRIPTION
I don't know why `yarn dev` started failing.
Found this solution in https://github.com/webpack/webpack-dev-server/issues/2029