### PR TITLE
fix(autocomplete): handle null description or content

### DIFF
--- a/frontend/src/AutocompleteWrapper.ts
+++ b/frontend/src/AutocompleteWrapper.ts
@@ -168,8 +168,14 @@ class AutocompleteWrapper {
     };
   }
 
-  private getSuggestionSnippet(hit: Hit<Data>) {
-    const { description, content } = hit._snippetResult!;
+  private getSuggestionSnippet(hit: Hit<Data>): string {
+    const description = hit._snippetResult?.description!;
+    const content = hit._snippetResult?.content!;
+    if (!description || !content) {
+      if (description) return description.value;
+      if (content) return content.value;
+      return '';
+    }
     if (description.matchLevel === 'full') return description.value;
     if (content.matchLevel === 'full') return content.value;
     if (description.matchLevel === 'partial') return description.value;


### PR DESCRIPTION
Follow-up of https://discourse.algolia.com/t/integrated-algolia-plugin-via-netlify-and-resulted-in-successful-build-but-the-build-status-has-hung-remained-at-building-within-netlify-dashboard/11158/18
When a result's description or content is `null` the autocomplete will fail.
This PR fixes it.