### PR TITLE
feat(frontend): add warning when no search input is found

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 
 <h2 align="center">Algolia Netlify plugin</h2>
 
-
 Automatically index your website to Algolia when deploying your project to Netlify with the Algolia Crawler.
 
 - [What is Algolia?](https://www.algolia.com/doc/guides/getting-started/what-is-algolia/)
@@ -114,7 +113,8 @@ You can find an HTML code snippet in the [Crawler Admin Console](https://crawler
 </script>
 ```
 
-This code automatically adds a search autocomplete widget on your website, using your newly created Algolia index. Please refer to the [full documentation](https://github.com/algolia/algoliasearch-netlify/tree/master/frontend) to configure this front-end plugin.
+This code automatically adds a search autocomplete widget on your website on all `<input type="search" />` tags, using your newly created Algolia index.  
+Please refer to the [full documentation](https://github.com/algolia/algoliasearch-netlify/tree/master/frontend) to configure this front-end plugin.
 
 <img src="/docs/screenshots/frontend.png?raw=true" alt="Autocomplete preview">
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,7 @@
 
 `algoliasearch-netlify-frontend` is the front-end bundle we recommend to use with our Netlify plugin.
 It's designed to be compatible with the index structure extracted by the [plugin](../plugin).
+It enhances existing search inputs in your website with an autocomplete menu providing search as you type results.
 
 ## Usage
 
@@ -38,6 +39,7 @@ algoliasearchNetlify({
   },
   color: '#3c4fe0',                             // Main color
   debug: false,                                 // Debug mode (keeps the autocomplete open)
+  silenceWarnings: false,                       // Disable warnings (e.g. no search input found)
   poweredBy: true,                              // Controls displaying the logo (mandatory with our FREE plan)
 });
 ```

--- a/frontend/src/AlgoliasearchNetlify.ts
+++ b/frontend/src/AlgoliasearchNetlify.ts
@@ -12,6 +12,7 @@ const defaultOptions: Omit<
   },
   color: '#3c4fe0',
   debug: false,
+  silenceWarnings: false,
   poweredBy: true,
 };
 

--- a/frontend/src/AutocompleteWrapper.ts
+++ b/frontend/src/AutocompleteWrapper.ts
@@ -49,11 +49,24 @@ class AutocompleteWrapper {
     autocomplete: { hitsPerPage, inputSelector },
     color,
     debug,
+    silenceWarnings,
     poweredBy,
   }: Options) {
     addCss(templates.autocomplete.css(color));
 
     const $inputs = this.getInputs(inputSelector);
+
+    if ($inputs.length === 0 && !silenceWarnings) {
+      const inputSelectorText = JSON.stringify(inputSelector);
+      console.warn(
+        [
+          `[Algolia] No input matched our default selector ${inputSelectorText}`,
+          'The integration needs a search input to be active on your page. You can either:',
+          '- add an input that matches the selector',
+          '- or modify `autocomplete.inputSelector` to match your search input.',
+        ].join('\n')
+      );
+    }
 
     const autocompletes = $inputs.map(($input) => {
       const inputWidth = $input.getBoundingClientRect().width;

--- a/frontend/src/options.ts
+++ b/frontend/src/options.ts
@@ -16,5 +16,6 @@ export interface Options {
   };
   color: string;
   debug: boolean;
+  silenceWarnings: boolean;
   poweredBy: boolean;
 }


### PR DESCRIPTION
We've had multiple users confused by the fact that nothing changed on their website after adding the library.
This PR adds a warning in the browser console when we don't find any matching input.