### PR TITLE
feat: use algoliasearch-lite to avoid preflight requests

### DIFF
--- a/frontend/src/AutocompleteWrapper.ts
+++ b/frontend/src/AutocompleteWrapper.ts
@@ -7,11 +7,11 @@ if (!isMsie()) {
   delete css.inputWithNoHint.verticalAlign;
 }
 
-import type { SearchClient, SearchIndex } from 'algoliasearch';
+import type { SearchClient, SearchIndex } from 'algoliasearch/lite';
 import type { RequestOptions } from '@algolia/transporter';
 import type { Hit } from '@algolia/client-search';
 
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 import autocomplete from 'autocomplete.js';
 
 import type { Options } from './options';

--- a/scripts/generate_netlify_toml.sh
+++ b/scripts/generate_netlify_toml.sh
@@ -1,4 +1,4 @@
- #! /bin/bash
+#! /bin/bash
 
 set -e
 cd "$(dirname "${BASH_SOURCE[0]}")"


### PR DESCRIPTION
The frontend bundle currently sends [preflight requests](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) (a.k.a. `OPTIONS`) because the Algolia credentials are passed in headers by default in `algoliasearch`.

`algoliasearch-lite` put them in query params (c.f. [doc](https://www.algolia.com/doc/api-client/advanced/configure-the-client/javascript/?language=javascript#auth-mode)), avoiding this additional request. It is recommended for frontend implementations.