### PR TITLE
fix(frontend): add a default color for results title

### DIFF
--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -69,6 +69,7 @@
 .aa-hit--title {
   font-size: 1.1em;
   font-weight: bold;
+  color: black;
 
   .aa-hit--highlight {
     position: relative;


### PR DESCRIPTION
There is no default color for results titles, so they currently take the color of the parent div, which doesn't work always well ([here](https://confident-brattain-d5a164.netlify.app/) for example).

Putting the default color to black.