### PR TITLE
feat: new params pathPrefix, customDomain

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,6 +1,6 @@
 # FAQ
 
-This is a general purpose FAQ. If you are looking for technical answers, go to our [Technical documentation](Extraction.md).
+This is a general purpose FAQ. If you are looking for more technical answers, go to our [Technical documentation](Extraction.md).
 
 ## I want to extract more information from my pages<!-- omit in toc -->
 
@@ -30,7 +30,14 @@ You can help the crawler by:
 
 ## I have a custom domain<!-- omit in toc -->
 
-The plugin currently only support custom domains that are configured in Netlify (**Settings > Domain management > Custom domains**).
+The plugin can automatically alias your custom domain:
+
+- we automatically alias custom domains that are configured in Netlify (**Settings > Domain management > Custom domains**).
+- if not possible to configure that in Netlify, an option `customDomain` is available in your [netlify.toml](/plugin/README.md#inputs)
+
+## My website is not at the root level<!-- omit in toc -->
+
+The plugin can automatically alias path (aka removing path prefix), by setting the option `pathPrefix` in your [netlify.toml](/plugin/README.md#inputs)
 
 ## Do I need to display the Algolia logo?
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -37,7 +37,7 @@ The plugin can automatically alias your custom domain:
 
 ## My website is not at the root level<!-- omit in toc -->
 
-The plugin can automatically alias path (aka removing path prefix), by setting the option `pathPrefix` in your [netlify.toml](/plugin/README.md#inputs)
+The plugin can automatically alias path (i.e. removing path prefix), by setting the option `pathPrefix` in your [netlify.toml](/plugin/README.md#inputs)
 
 ## Do I need to display the Algolia logo?
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -22,6 +22,10 @@ Plugin inputs can be set in `netlify.toml`. They're all optional.
   - `feat/*`: matches all branches starting with `feat/`
   - `*-bug`: matches all branches finishing with `-bug`
 - `disabled` - _Default: `false`_ - Use to disable the plugin without removing it.
+- `pathPrefix` - The prefix of your website if it's not at the root level.
+  Putting "pathPrefix: /blog" will alias `/blog` to `/`
+- `customDomain` - The custom domain that you use, if it's not possible to define it on your Netlify's settings.
+  Putting "customDomain: example.com" will alias `example.com` to `<your-site-url>.netlify.app`
 
 Example:
 
@@ -30,6 +34,9 @@ Example:
 package = "@algolia/netlify-plugin-crawler"
   [plugins.inputs]
   branches = ['master', 'develop', 'feat/add-algolia']
+  disabled = true
+  pathPrefix = "/blog"
+  customDomain = "example.com"
 ```
 
 ### Environment variables

--- a/plugin/manifest.yml
+++ b/plugin/manifest.yml
@@ -9,4 +9,4 @@ inputs:
   - name: pathPrefix
     description: The prefix of your website if it's not at the root level, e.g /blog
   - name: customDomain
-    description: The custom domain that you use, if it's not possible to define it on your Netlify settings.
+    description: The custom domain that you use, if it's not possible to define it on your Netlify's settings.

--- a/plugin/manifest.yml
+++ b/plugin/manifest.yml
@@ -6,3 +6,7 @@ inputs:
   - name: branches
     description: Branches to index. Each branch in this array will have its content crawled in a dedicated index.
     default: ['master', 'main']
+  - name: pathPrefix
+    description: The prefix of your website if it's not at the root level, e.g /blog
+  - name: customDomain
+    description: The custom domain that you use, if it's not possible to define it on your Netlify settings.

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -4,26 +4,7 @@ import fetch, { Response } from 'node-fetch';
 import { version } from '../package.json';
 import { loadDevEnvVariables } from './dev';
 import { starMatch } from './starMatch';
-
-interface BuildParams {
-  constants: {
-    SITE_ID: string;
-    IS_LOCAL: boolean;
-  };
-  inputs: {
-    disabled: boolean;
-    branches: string[];
-  };
-  utils: {
-    status: {
-      show(params: { title?: string; summary: string; text?: string }): void;
-    };
-    build: {
-      // failBuild(str: string): void; // Do not use https://github.com/algolia/algoliasearch-netlify/issues/69
-      failPlugin(str: string): void;
-    };
-  };
-}
+import { BuildParams } from './types';
 
 function createSummaryLogger(
   show: BuildParams['utils']['status']['show']
@@ -67,6 +48,8 @@ export async function onSuccess(params: BuildParams): Promise<void> {
   const algoliaApiKey = process.env.ALGOLIA_API_KEY;
 
   const branches = inputs.branches;
+  const pathPrefix = inputs.pathPrefix;
+  const customDomain = inputs.customDomain;
 
   if (isEnvDisabled) {
     summary(`Disabled by the "ALGOLIA_DISABLED" environment variable`);
@@ -115,7 +98,14 @@ export async function onSuccess(params: BuildParams): Promise<void> {
 
   let response: Response;
   try {
-    const body = JSON.stringify({ branch, siteName, deployPrimeUrl, version });
+    const body = JSON.stringify({
+      branch,
+      siteName,
+      deployPrimeUrl,
+      version,
+      pathPrefix,
+      customDomain,
+    });
     console.log('Sending request to crawl', endpoint);
     if (isDebugMode) {
       console.log(body);

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -1,0 +1,21 @@
+export interface BuildParams {
+  constants: {
+    SITE_ID: string;
+    IS_LOCAL: boolean;
+  };
+  inputs: {
+    disabled: boolean;
+    branches: string[];
+    pathPrefix?: string;
+    customDomain?: string;
+  };
+  utils: {
+    status: {
+      show(params: { title?: string; summary: string; text?: string }): void;
+    };
+    build: {
+      // failBuild(str: string): void; // Do not use https://github.com/algolia/algoliasearch-netlify/issues/69
+      failPlugin(str: string): void;
+    };
+  };
+}

--- a/plugin/tsconfig.json
+++ b/plugin/tsconfig.json
@@ -4,5 +4,7 @@
     "rootDir": "src",
     "outDir": "./dist"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
- pathPrefix, to alias path when a Netlify site is not hosted at the root level, e.g:

```yml
pathPrefix: /blog
# /blog will be aliased to /
```  

- customDomain, when setting the domain in Netlify settings is not possible, e.g:

```yml
customDomain: example.com
# example.com will be aliased to "foo-bar.netlify.app" 
```  