### PR TITLE
fix(frontend): suggestionSnippet correct logic

### DIFF
--- a/frontend/src/AutocompleteWrapper.ts
+++ b/frontend/src/AutocompleteWrapper.ts
@@ -136,8 +136,8 @@ class AutocompleteWrapper {
 }
 
 function getSuggestionSnippet(hit: Hit<AlgoliaRecord>): string | null {
-  // Description and content are always returned by default
-  // unless indexSettings were modified even they don't match
+  // If they are defined as `searchableAttributes`, 'description' and 'content' are always
+  // present in the `_snippetResult`, even if they don't match.
   // So we need to have 1 check on the presence and 1 check on the match
   const description = hit._snippetResult?.description;
   const content = hit._snippetResult?.content;


### PR DESCRIPTION
The logic was correct in previous version by Matthieu but I did not get why it was done like that.
The problem is that Algolia always return _snipperResults even when no match, so we need to check two different condition to be sure.

Added comment so we don't forget.

(NB: we need to add some unit test on this kind of logic but it's not setup yet)