### PR TITLE
fix(autocomplete): use the new Requester API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,8 +108,9 @@ typings/
 # Built files
 dist/
 
-# VSCode files
+# IDEs
 .vscode
+.idea
 
 # npm package lock
 package-lock.json

--- a/frontend/src/AutocompleteWrapper.ts
+++ b/frontend/src/AutocompleteWrapper.ts
@@ -1,11 +1,10 @@
-import { autocomplete } from '@algolia/autocomplete-js';
+import { autocomplete, getAlgoliaResults } from '@algolia/autocomplete-js';
 import type {
   AutocompleteApi,
   AutocompleteSource,
   SourceTemplates,
 } from '@algolia/autocomplete-js';
 import type { HighlightedHit } from '@algolia/autocomplete-preset-algolia';
-import { getAlgoliaHits } from '@algolia/autocomplete-preset-algolia';
 import algoliasearch from 'algoliasearch/lite';
 import type { SearchClient } from 'algoliasearch/lite';
 
@@ -103,7 +102,7 @@ class AutocompleteWrapper {
     const res: AutocompleteSource<HighlightedHit<AlgoliaRecord>> = {
       sourceId: 'algoliaHits',
       getItems: ({ query }) => {
-        return getAlgoliaHits({
+        return getAlgoliaResults({
           searchClient: this.client,
           queries: [
             {


### PR DESCRIPTION
A new version of Autocomplete's Requester API was introduced in `alpha.46`, where `getAlgoliaHits` was replaced by `getAlgoliaResuts`: [Changelog](https://github.com/algolia/autocomplete/blob/next/CHANGELOG.md#100-alpha46-2021-04-22)
The old function has been cleaned up for the v1 release, so our UI is currently broken on the master branch.

### Changes

- Use `getAlgoliaResuts` instead of `getAlgoliaHits`